### PR TITLE
Update diffusion_cg.py

### DIFF
--- a/scripts/diffusion_cg.py
+++ b/scripts/diffusion_cg.py
@@ -70,7 +70,6 @@ class DiffusionCG(scripts.Script):
 
         with InputAccordion(
             label=f"{self.title()} v{VERSION}",
-            open=False,
             value=(
                 ((not is_img2img) and (c_t2i or n_t2i))
                 or (is_img2img and (c_i2i or n_i2i))


### PR DESCRIPTION
Hello again! Another (not very necessary) little fix of this warning:

```
...\modules\gradio_extensons.py:25: GradioUnusedKwargWarning: You have unused kwarg parameters in InputAccordion, please remove them: {'open': False}
  res = original_IOComponent_init(self, *args, **kwargs)
```

I wanted to create issue, but then I changed my mind and decided that it would be more convenient for you to consider this in this format.